### PR TITLE
fix: infinite loop in server.cpp

### DIFF
--- a/brazier/include/brazier/server.hpp
+++ b/brazier/include/brazier/server.hpp
@@ -65,6 +65,9 @@ namespace brazier {
         std::atomic<int> connection_count_{ 0 };
         std::atomic<int> total_requests_{ 0 };
 
+        std::thread stats_thread_;                   
+        std::atomic<bool> shutdown_flag_{ false };
+
     public:
         Server(const std::string& host, unsigned short port);
 

--- a/brazier/src/Server.cpp
+++ b/brazier/src/Server.cpp
@@ -72,19 +72,20 @@ void brazier::Server::run() {
         Logger::log("Starting " + std::to_string(threads_count) + " worker threads", "INFO");
 
         for (int i = 0; i < threads_count; ++i) {
-            threads_.emplace_back([this, i] {
+            threads_.emplace_back([this] {
                 io_.run();
-                });
+            });
         }
 
-        std::thread stats_thread([this] {
-            while (true) {
+        shutdown_flag_.store(false, std::memory_order_release);
+        stats_thread_ = std::thread([this] {
+            while (!shutdown_flag_.load(std::memory_order_acquire)) {
                 std::this_thread::sleep_for(10s);
+                if (shutdown_flag_.load(std::memory_order_acquire)) break;
                 Logger::log("STATS - Active connections: " + std::to_string(connection_count_.load()) +
                     ", Total requests: " + std::to_string(total_requests_.load()), "INFO");
             }
             });
-        stats_thread.detach();
 
         for (auto& t : threads_) {
             if (t.joinable()) {
@@ -99,8 +100,14 @@ void brazier::Server::run() {
 }
 
 void brazier::Server::stop() {
+    shutdown_flag_.store(true);
+
     work_guard_.reset();
     io_.stop();
+
+    if (stats_thread_.joinable()) {
+        stats_thread_.join();
+    }
     Logger::log("Server stopped", "INFO");
 }
 


### PR DESCRIPTION
# Pull Request

**Related Issues:**

- #134 

**Type of Change:**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Performance
- [x] Refactoring
- [ ] Tests

**Description:**
fix infinite loop in statistics threads in server.cpp

**Implementation Details:**

added new flag and field in server class:

```cpp
std::thread stats_thread_;                   
std::atomic<bool> shutdown_flag_{ false };
```

**Testing:**
brazier_tests.exe

**Breaking Changes:**
(If any, describe what breaks and how to migrate)

**Checklist:**

- [x] Code compiles
- [x] Tests pass
- [x] Documentation updated
- [x] Changelog updated
- [x] No sensitive data exposed
